### PR TITLE
Friendly defaults for macOS

### DIFF
--- a/run-chrome.sh
+++ b/run-chrome.sh
@@ -4,8 +4,14 @@ remoteDebugPort=9222
 chromeBinary="google-chrome-beta"
 
 
+case $OSTYPE in darwin*) 
+  chromeBinary=/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome
+esac
+
+chromeVersion=$("$chromeBinary" --version | grep -oE "\d{1,4}" | head -n1)
+
 if [ "$1" = "headless" ]; then
-   $chromeBinary --headless --disable-gpu --remote-debugging-port=${remoteDebugPort}
+   "$chromeBinary" --headless --disable-gpu --remote-debugging-port=${remoteDebugPort}
 else
-   $chromeBinary --remote-debugging-port=${remoteDebugPort}
+   "$chromeBinary" --remote-debugging-port=${remoteDebugPort}
 fi


### PR DESCRIPTION
@N0taN3rd Please check that the syntax don't break it on Linux. Relevant to #2 (but does not yet fix).