### PR TITLE
Minor correction: "heretrix" is female

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 `Squidwarc` aims to address the need for a high fidelity crawler akin to Heritrix while still
 easy enough for the personal archivist to setup and use.
 
-`Squidwarc` does not seek (at the moment) to dethrone Heritrix as the king of wide archival crawls rather
+`Squidwarc` does not seek (at the moment) to dethrone Heritrix as the queen of wide archival crawls rather
 seeks to address Heritrix's short comings namely
 - No JavaScript execution
 - Everything is plain text


### PR DESCRIPTION
Heretrix is a [female noun](https://www.collinsdictionary.com/us/dictionary/english/heretrix), and therefore, it would be more consistent to refer to the software as the "queen" of archival crawls instead of the "king".