### PR TITLE
Fix typo in quick start within manual

### DIFF
--- a/manual/index.md
+++ b/manual/index.md
@@ -28,7 +28,7 @@ git clone https://github.com/N0taN3rd/Squidwarc.git
 
 cd Squidwarc
 
-./boostrap.sh
+./bootstrap.sh
 
 ./run-crawl.sh -c conf.json
 ```


### PR DESCRIPTION
@N0taN3rd I was checking out the details docs for crawl params and noticed this typo.